### PR TITLE
Update helper.py

### DIFF
--- a/piptegrator/helper.py
+++ b/piptegrator/helper.py
@@ -94,7 +94,7 @@ def regen_file(root_dir, basename, extension, requirements, metadata):
         for req in requirements[basename]:
             if 'other' in req:
                 line = req['other']
-                if line.startswith('#    {} '.format(config.PIP_COMPILE_CMD)):
+                if config.PIP_COMPILE_CMD in line.split('#', 1)[0]:
                     line = '#    {}  # --help for options'.format(PARAMS['this_script'])
             else:
                 reqname = req['reqname']


### PR DESCRIPTION
This commit changes the behavior of comment handling to deal with both full-line and inline comments; using `startswith()` was missing and then duplicating comments that occur after the first character in the line. 